### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package Publish
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/willvin313/caprover-api-js/security/code-scanning/3](https://github.com/willvin313/caprover-api-js/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves reading repository contents and publishing to npm, the `contents: read` permission is sufficient. This change should be applied at the root level of the workflow to cover all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
